### PR TITLE
Update Node.js runtime from 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: RuboCop Problem Matchers
 description: Setup Problem Matchers for RuboCop.
 runs:
-  using: node16
+  using: node20
   main: index.js
 branding:
   color: red


### PR DESCRIPTION
This action causes following warning message:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: r7kamura/rubocop-problem-matchers-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.